### PR TITLE
Fix parse date

### DIFF
--- a/hashcash.gemspec
+++ b/hashcash.gemspec
@@ -18,8 +18,3 @@ XEOF
 
     gem.files = Dir['lib/hashcash.rb'] + Dir['test/test_hashcash.rb'] 
 end
-
-if $0 == __FILE__
-    Gem.manage_gems
-    Gem::Builder.new(spec).build
-end

--- a/lib/hashcash.rb
+++ b/lib/hashcash.rb
@@ -126,7 +126,7 @@ module HashCash
 			hour  = date[6,2].to_i
 			min   = date[8,2].to_i
 			sec   = date[10,2].to_i
-			Time.utc(year, month, day, hour, min, sec)
+			Time.utc(2000 + year, month, day, hour, min, sec)
 		end
 
 		# Convert a date to the string format used in the stamps


### PR DESCRIPTION
Hi,

When I run the test I have the following error because the year is parsed on 2 digits, so 2000 years are missing :

```
ruby -I . test/test_hashcash.rb 
Loaded suite test/test_hashcash
Started
..F
     16:         s = HashCash::Stamp.new(:stamp => WIKIPEDIA_EXAMPLE)
     17:         assert_equal(1, s.version.to_i)
     18:         assert_equal(20, s.bits)
  => 19:         assert_equal(2006, s.date.year)
     20:         assert_equal(4, s.date.month)
     21:         assert_equal(8, s.date.day)
     22: 	end
test/test_hashcash.rb:19:in `test_parsing'
<2006> expected but was
<6>
```

Moreover, the gem cannot be installed with a git or path option :

```ruby
gem "hashcash", git: "https://github.com/alech/hashcash.git", ref: "fd57403"
```

Because the gemspec try to build the gem. I don't think it's a safe behaviour for a gemspec. I also fixed it.

That would be great if you can merge and publish a new version of the gem. Or if you don't want my PR, let me know too please.

Best regards.